### PR TITLE
Replaced empty string with class

### DIFF
--- a/src/Editor.php
+++ b/src/Editor.php
@@ -23,7 +23,7 @@ class Editor
      */
     public static function addScripts($plugins)
     {
-        global $recrasPlugin;
+        $recrasPlugin = new \Recras\Plugin;
 
         $plugins['recras'] = $recrasPlugin->baseUrl . '/editor/plugin.js';
         return $plugins;


### PR DESCRIPTION
Fix for empty $recrasPlugin variable causing error in the WordPress Editor while using legacy or new block editor.